### PR TITLE
Configure bot to run under gunicorn

### DIFF
--- a/main.py
+++ b/main.py
@@ -326,15 +326,12 @@ def start_bot_logic():
     asyncio.run(main())
 
 # =================================================================
-# הפעלת הבוט בתהליך רקע והשארת התהליך הראשי ל-Flask
+# הפעלת הבוט בתהליך רקע ברמה הגלובלית של המודול
+# כך ש-Gunicorn יפעיל אותו בעת הייבוא.
 # =================================================================
-if __name__ == '__main__':
-    logging.info("Creating bot thread...")
-    bot_thread = threading.Thread(target=start_bot_logic)
-    bot_thread.daemon = True
-    bot_thread.start()
-    
-    logging.info("Starting Flask server for Render health checks...")
-    # לתשומת לבך: אין צורך להוסיף app.run() כאן.
-    # Gunicorn יריץ את האובייקט 'app' בעצמו.
-    # אנחנו משאירים את הבלוק הזה ריק בכוונה אחרי התחלת ה-thread.
+logging.info("Creating bot thread to run in the background...")
+bot_thread = threading.Thread(target=start_bot_logic)
+bot_thread.daemon = True
+bot_thread.start()
+
+logging.info("Background bot thread started. The main thread will now be managed by Gunicorn.")


### PR DESCRIPTION
Refactor bot initialization to run under Gunicorn by removing the `if __name__ == '__main__':` block.

Previously, the bot's background thread was only started when `main.py` was executed directly. For Gunicorn to manage the application, the bot initialization needs to occur at the module's global level, ensuring it starts upon import.

---
<a href="https://cursor.com/background-agent?bcId=bc-a959b5ae-6e0f-4bca-aa03-2056e8c35ef4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a959b5ae-6e0f-4bca-aa03-2056e8c35ef4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>