### PR TITLE
Fix date comparison in get_channel_posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ class TelegramSummaryBot:
             
             # קריאת הודעות מהערוץ
             async for message in self.bot.iter_history(f"@{self.channel_username}", limit=100):
-                if message.date.replace(tzinfo=pytz.UTC).astimezone(self.israel_tz) < since_date:
+                if message.date.astimezone(self.israel_tz) < since_date:
                     break
                 
                 if message.text:


### PR DESCRIPTION
Fix date comparison logic in `get_channel_posts` to prevent premature loop exit.

The previous code incorrectly applied `replace(tzinfo=pytz.UTC)` to an already UTC-aware `message.date` object before converting to `israel_tz`, leading to potential comparison errors. The fix directly converts the UTC-aware `message.date` to `self.israel_tz` for accurate comparison with `since_date`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a5e3a25-64f9-4728-9d08-f5c87f9ec75a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a5e3a25-64f9-4728-9d08-f5c87f9ec75a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>